### PR TITLE
Refactor CMakeLists.txt and clean up includes in test_mock_example.cpp

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,10 @@
 include(CTest)
 
+# Set CMake policy for linker search path behavior
+if(COMMAND cmake_policy)
+    cmake_policy(SET CMP0003 NEW)
+endif(COMMAND cmake_policy)
+
 # Copy .env file to build root directory for tests (CTest runs from there)
 if(EXISTS "${PROJECT_SOURCE_DIR}/.env")
     configure_file(

--- a/test/test_mock_example.cpp
+++ b/test/test_mock_example.cpp
@@ -8,8 +8,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "mocks/mock_serial_port.hpp"
 #include "mocks/mock_can_socket.hpp"
-#include "pattern/socketcan_bridge.hpp"
-#include "pattern/usb_adapter.hpp"
 #include <thread>
 #include <chrono>
 


### PR DESCRIPTION
Update CMake policy settings for linker search path behavior and remove unused includes in the test file.